### PR TITLE
feat(DropBaseController): Criado Controller Genérico.

### DIFF
--- a/DROP-Ecommerce/DropCommerce.Domain/Interfaces/IRepository.cs
+++ b/DROP-Ecommerce/DropCommerce.Domain/Interfaces/IRepository.cs
@@ -8,6 +8,7 @@ public interface IRepository<T> where T : BaseEntity
     Task<IEnumerable<T>> GetAllAsync(CancellationToken cancellationToken = default);
     Task<IEnumerable<T>> GetListByListIdAsync(List<long> ids, CancellationToken cancellationToken = default);
     Task AddAsync(T entity, CancellationToken cancellationToken = default);
+    Task AddRangeAsync(IEnumerable<T> entities, CancellationToken cancellationToken = default);
     void Update(T entity);
     void UpdateRange(IEnumerable<T> entities);
     Task DeleteAsync(long id, CancellationToken cancellationToken = default);

--- a/DROP-Ecommerce/DropCommerce.Infrastructure.Data/Repositories/Base/Repository.cs
+++ b/DROP-Ecommerce/DropCommerce.Infrastructure.Data/Repositories/Base/Repository.cs
@@ -44,6 +44,11 @@ public class Repository<T> : IRepository<T> where T : BaseEntity
         await _dbSet.AddAsync(entity, cancellationToken);
     }
 
+    public async Task AddRangeAsync(IEnumerable<T> entities, CancellationToken cancellationToken = default)
+    {
+        await _dbSet.AddRangeAsync(entities, cancellationToken);
+    }
+
     #endregion
 
     #region Update

--- a/DROP-Ecommerce/src/Drop/DropCommerce.Api/Configuration/DependencyInjectionConfig.cs
+++ b/DROP-Ecommerce/src/Drop/DropCommerce.Api/Configuration/DependencyInjectionConfig.cs
@@ -8,6 +8,7 @@ public static class DependencyInjectionConfig
     public static IServiceCollection AddApiConfiguration(this IServiceCollection services, IConfiguration configuration)
     {
         services.AddHttpContextAccessor();
+        services.AddControllers();
         services.AddOpenApi();
 
         var connectionString = Environment.GetEnvironmentVariable("DROPCOMMERCE_CONNECTION_STRING")

--- a/DROP-Ecommerce/src/Drop/DropCommerce.Api/Controllers/Base/BaseController.cs
+++ b/DROP-Ecommerce/src/Drop/DropCommerce.Api/Controllers/Base/BaseController.cs
@@ -1,0 +1,101 @@
+using DropCommerce.Application.Result;
+using DropCommerce.Domain.Entity;
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+
+namespace DropCommerce.Api.Controllers.Base;
+
+[ApiController]
+[Route("api/[controller]")]
+public abstract class BaseController<TEntity, TCreateCommand, TCreateRangeCommand, TUpdateCommand, TUpdateRangeCommand> : ControllerBase
+    where TEntity : BaseEntity
+    where TCreateCommand : IRequest<Result<TEntity>>
+    where TCreateRangeCommand : IRequest<Result<List<TEntity>>>
+    where TUpdateCommand : IRequest<Result<TEntity>>
+    where TUpdateRangeCommand : IRequest<Result<List<TEntity>>>
+{
+    protected readonly IMediator _mediator;
+
+    protected BaseController(IMediator mediator)
+    {
+        _mediator = mediator;
+    }
+
+    [HttpPost("Add")]
+    public async Task<IActionResult> AddAsync([FromBody] TCreateCommand command)
+    {
+        var rangeCommand = WrapCreateInRange(command);
+        return await AddRangeAsync(rangeCommand);
+    }
+
+    [HttpPost("AddRange")]
+    public async Task<IActionResult> AddRangeAsync([FromBody] TCreateRangeCommand command)
+    {
+        var result = await _mediator.Send(command);
+        return HandleResult(result);
+    }
+
+    [HttpPut("Update")]
+    public async Task<IActionResult> UpdateAsync([FromBody] TUpdateCommand command)
+    {
+        var rangeCommand = WrapUpdateInRange(command);
+        return await UpdateRangeAsync(rangeCommand);
+    }
+
+    [HttpPut("UpdateRange")]
+    public async Task<IActionResult> UpdateRangeAsync([FromBody] TUpdateRangeCommand command)
+    {
+        var result = await _mediator.Send(command);
+        return HandleResult(result);
+    }
+
+    [HttpDelete("Delete/{id}")]
+    public async Task<IActionResult> DeleteAsync(long id)
+    {
+        return await DeleteRangeAsync(new List<long> { id });
+    }
+
+    [HttpDelete("DeleteRange")]
+    public async Task<IActionResult> DeleteRangeAsync([FromBody] List<long> ids)
+    {
+        var command = DeleteRangeCommand(ids);
+        var result = await _mediator.Send(command);
+        return HandleResult(result);
+    }
+
+    [HttpGet("GetAll")]
+    public async Task<IActionResult> GetAllAsync()
+    {
+        var query = GetAllQuery();
+        var result = await _mediator.Send(query);
+        return HandleResult(result);
+    }
+
+    [HttpGet("GetById/{id}")]
+    public async Task<IActionResult> GetByIdAsync(long id)
+    {
+        var query = GetByIdQuery(id);
+        var result = await _mediator.Send(query);
+        return HandleResult(result);
+    }
+
+    [HttpPost("GetListByListId")]
+    public async Task<IActionResult> GetListByListIdAsync([FromBody] List<long> ids)
+    {
+        var query = GetListByListIdQuery(ids);
+        var result = await _mediator.Send(query);
+        return HandleResult(result);
+    }
+
+    protected IActionResult HandleResult<T>(Result<T> result)
+    {
+        return result.IsSuccess ? Ok(result) : BadRequest(result);
+    }
+
+    protected abstract TCreateRangeCommand WrapCreateInRange(TCreateCommand command);
+    protected abstract TUpdateRangeCommand WrapUpdateInRange(TUpdateCommand command);
+    protected abstract IRequest<Result<bool>> DeleteRangeCommand(List<long> ids);
+    protected abstract IRequest<Result<List<TEntity>>> GetAllQuery();
+    protected abstract IRequest<Result<TEntity>> GetByIdQuery(long id);
+    protected abstract IRequest<Result<List<TEntity>>> GetListByListIdQuery(List<long> ids);
+}

--- a/DROP-Ecommerce/src/Drop/DropCommerce.Api/Controllers/DropAuditLog/DropAuditLogController.cs
+++ b/DROP-Ecommerce/src/Drop/DropCommerce.Api/Controllers/DropAuditLog/DropAuditLogController.cs
@@ -1,0 +1,46 @@
+using DropCommerce.Api.Controllers.Base;
+using DropCommerce.Application.Features.Commands;
+using DropCommerce.Application.Result;
+using DropCommerce.Domain.Entity;
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+
+namespace DropCommerce.Api.Controllers;
+
+[Route("api/drop-audit-log")]
+public class DropAuditLogController : BaseController<DropAuditLog, CreateDropAuditLogCommand, CreateListDropAuditLogCommand, UpdateDropAuditLogCommand, UpdateListDropAuditLogCommand>
+{
+    public DropAuditLogController(IMediator mediator) : base(mediator)
+    {
+    }
+
+    protected override CreateListDropAuditLogCommand WrapCreateInRange(CreateDropAuditLogCommand command)
+    {
+        return new CreateListDropAuditLogCommand(new List<CreateDropAuditLogCommand> { command });
+    }
+
+    protected override UpdateListDropAuditLogCommand WrapUpdateInRange(UpdateDropAuditLogCommand command)
+    {
+        return new UpdateListDropAuditLogCommand(new List<UpdateDropAuditLogCommand> { command });
+    }
+
+    protected override IRequest<Result<bool>> DeleteRangeCommand(List<long> ids)
+    {
+        return new DeleteListDropAuditLogCommand(ids);
+    }
+
+    protected override IRequest<Result<List<DropAuditLog>>> GetAllQuery()
+    {
+        return new GetAllDropAuditLogQuery();
+    }
+
+    protected override IRequest<Result<DropAuditLog>> GetByIdQuery(long id)
+    {
+        return new GetByIdDropAuditLogQuery(id);
+    }
+
+    protected override IRequest<Result<List<DropAuditLog>>> GetListByListIdQuery(List<long> ids)
+    {
+        return new GetListByListIdDropAuditLogQuery(ids);
+    }
+}

--- a/DROP-Ecommerce/src/Drop/DropCommerce.Api/Controllers/DropCoupon/DropCouponController.cs
+++ b/DROP-Ecommerce/src/Drop/DropCommerce.Api/Controllers/DropCoupon/DropCouponController.cs
@@ -1,0 +1,46 @@
+using DropCommerce.Api.Controllers.Base;
+using DropCommerce.Application.Features.Commands;
+using DropCommerce.Application.Result;
+using DropCommerce.Domain.Entity;
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+
+namespace DropCommerce.Api.Controllers;
+
+[Route("api/drop-coupon")]
+public class DropCouponController : BaseController<DropCoupon, CreateDropCouponCommand, CreateListDropCouponCommand, UpdateDropCouponCommand, UpdateListDropCouponCommand>
+{
+    public DropCouponController(IMediator mediator) : base(mediator)
+    {
+    }
+
+    protected override CreateListDropCouponCommand WrapCreateInRange(CreateDropCouponCommand command)
+    {
+        return new CreateListDropCouponCommand(new List<CreateDropCouponCommand> { command });
+    }
+
+    protected override UpdateListDropCouponCommand WrapUpdateInRange(UpdateDropCouponCommand command)
+    {
+        return new UpdateListDropCouponCommand(new List<UpdateDropCouponCommand> { command });
+    }
+
+    protected override IRequest<Result<bool>> DeleteRangeCommand(List<long> ids)
+    {
+        return new DeleteListDropCouponCommand(ids);
+    }
+
+    protected override IRequest<Result<List<DropCoupon>>> GetAllQuery()
+    {
+        return new GetAllDropCouponQuery();
+    }
+
+    protected override IRequest<Result<DropCoupon>> GetByIdQuery(long id)
+    {
+        return new GetByIdDropCouponQuery(id);
+    }
+
+    protected override IRequest<Result<List<DropCoupon>>> GetListByListIdQuery(List<long> ids)
+    {
+        return new GetListByListIdDropCouponQuery(ids);
+    }
+}

--- a/DROP-Ecommerce/src/Drop/DropCommerce.Api/Controllers/DropEvent/DropEventController.cs
+++ b/DROP-Ecommerce/src/Drop/DropCommerce.Api/Controllers/DropEvent/DropEventController.cs
@@ -1,0 +1,46 @@
+using DropCommerce.Api.Controllers.Base;
+using DropCommerce.Application.Features.Commands;
+using DropCommerce.Application.Result;
+using DropCommerce.Domain.Entity;
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+
+namespace DropCommerce.Api.Controllers;
+
+[Route("api/drop-event")]
+public class DropEventController : BaseController<DropEvent, CreateDropEventCommand, CreateListDropEventCommand, UpdateDropEventCommand, UpdateListDropEventCommand>
+{
+    public DropEventController(IMediator mediator) : base(mediator)
+    {
+    }
+
+    protected override CreateListDropEventCommand WrapCreateInRange(CreateDropEventCommand command)
+    {
+        return new CreateListDropEventCommand(new List<CreateDropEventCommand> { command });
+    }
+
+    protected override UpdateListDropEventCommand WrapUpdateInRange(UpdateDropEventCommand command)
+    {
+        return new UpdateListDropEventCommand(new List<UpdateDropEventCommand> { command });
+    }
+
+    protected override IRequest<Result<bool>> DeleteRangeCommand(List<long> ids)
+    {
+        return new DeleteListDropEventCommand(ids);
+    }
+
+    protected override IRequest<Result<List<DropEvent>>> GetAllQuery()
+    {
+        return new GetAllDropEventQuery();
+    }
+
+    protected override IRequest<Result<DropEvent>> GetByIdQuery(long id)
+    {
+        return new GetByIdDropEventQuery(id);
+    }
+
+    protected override IRequest<Result<List<DropEvent>>> GetListByListIdQuery(List<long> ids)
+    {
+        return new GetListByListIdDropEventQuery(ids);
+    }
+}

--- a/DROP-Ecommerce/src/Drop/DropCommerce.Api/Controllers/DropNotification/DropNotificationController.cs
+++ b/DROP-Ecommerce/src/Drop/DropCommerce.Api/Controllers/DropNotification/DropNotificationController.cs
@@ -1,0 +1,46 @@
+using DropCommerce.Api.Controllers.Base;
+using DropCommerce.Application.Features.Commands;
+using DropCommerce.Application.Result;
+using DropCommerce.Domain.Entity;
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+
+namespace DropCommerce.Api.Controllers;
+
+[Route("api/drop-notification")]
+public class DropNotificationController : BaseController<DropNotification, CreateDropNotificationCommand, CreateListDropNotificationCommand, UpdateDropNotificationCommand, UpdateListDropNotificationCommand>
+{
+    public DropNotificationController(IMediator mediator) : base(mediator)
+    {
+    }
+
+    protected override CreateListDropNotificationCommand WrapCreateInRange(CreateDropNotificationCommand command)
+    {
+        return new CreateListDropNotificationCommand(new List<CreateDropNotificationCommand> { command });
+    }
+
+    protected override UpdateListDropNotificationCommand WrapUpdateInRange(UpdateDropNotificationCommand command)
+    {
+        return new UpdateListDropNotificationCommand(new List<UpdateDropNotificationCommand> { command });
+    }
+
+    protected override IRequest<Result<bool>> DeleteRangeCommand(List<long> ids)
+    {
+        return new DeleteListDropNotificationCommand(ids);
+    }
+
+    protected override IRequest<Result<List<DropNotification>>> GetAllQuery()
+    {
+        return new GetAllDropNotificationQuery();
+    }
+
+    protected override IRequest<Result<DropNotification>> GetByIdQuery(long id)
+    {
+        return new GetByIdDropNotificationQuery(id);
+    }
+
+    protected override IRequest<Result<List<DropNotification>>> GetListByListIdQuery(List<long> ids)
+    {
+        return new GetListByListIdDropNotificationQuery(ids);
+    }
+}

--- a/DROP-Ecommerce/src/Drop/DropCommerce.Api/Controllers/DropOrder/DropOrderController.cs
+++ b/DROP-Ecommerce/src/Drop/DropCommerce.Api/Controllers/DropOrder/DropOrderController.cs
@@ -1,0 +1,46 @@
+using DropCommerce.Api.Controllers.Base;
+using DropCommerce.Application.Features.Commands;
+using DropCommerce.Application.Result;
+using DropCommerce.Domain.Entity;
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+
+namespace DropCommerce.Api.Controllers;
+
+[Route("api/drop-order")]
+public class DropOrderController : BaseController<DropOrder, CreateDropOrderCommand, CreateListDropOrderCommand, UpdateDropOrderCommand, UpdateListDropOrderCommand>
+{
+    public DropOrderController(IMediator mediator) : base(mediator)
+    {
+    }
+
+    protected override CreateListDropOrderCommand WrapCreateInRange(CreateDropOrderCommand command)
+    {
+        return new CreateListDropOrderCommand(new List<CreateDropOrderCommand> { command });
+    }
+
+    protected override UpdateListDropOrderCommand WrapUpdateInRange(UpdateDropOrderCommand command)
+    {
+        return new UpdateListDropOrderCommand(new List<UpdateDropOrderCommand> { command });
+    }
+
+    protected override IRequest<Result<bool>> DeleteRangeCommand(List<long> ids)
+    {
+        return new DeleteListDropOrderCommand(ids);
+    }
+
+    protected override IRequest<Result<List<DropOrder>>> GetAllQuery()
+    {
+        return new GetAllDropOrderQuery();
+    }
+
+    protected override IRequest<Result<DropOrder>> GetByIdQuery(long id)
+    {
+        return new GetByIdDropOrderQuery(id);
+    }
+
+    protected override IRequest<Result<List<DropOrder>>> GetListByListIdQuery(List<long> ids)
+    {
+        return new GetListByListIdDropOrderQuery(ids);
+    }
+}

--- a/DROP-Ecommerce/src/Drop/DropCommerce.Api/Controllers/DropOrderItem/DropOrderItemController.cs
+++ b/DROP-Ecommerce/src/Drop/DropCommerce.Api/Controllers/DropOrderItem/DropOrderItemController.cs
@@ -1,0 +1,46 @@
+using DropCommerce.Api.Controllers.Base;
+using DropCommerce.Application.Features.Commands;
+using DropCommerce.Application.Result;
+using DropCommerce.Domain.Entity;
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+
+namespace DropCommerce.Api.Controllers;
+
+[Route("api/drop-order-item")]
+public class DropOrderItemController : BaseController<DropOrderItem, CreateDropOrderItemCommand, CreateListDropOrderItemCommand, UpdateDropOrderItemCommand, UpdateListDropOrderItemCommand>
+{
+    public DropOrderItemController(IMediator mediator) : base(mediator)
+    {
+    }
+
+    protected override CreateListDropOrderItemCommand WrapCreateInRange(CreateDropOrderItemCommand command)
+    {
+        return new CreateListDropOrderItemCommand(new List<CreateDropOrderItemCommand> { command });
+    }
+
+    protected override UpdateListDropOrderItemCommand WrapUpdateInRange(UpdateDropOrderItemCommand command)
+    {
+        return new UpdateListDropOrderItemCommand(new List<UpdateDropOrderItemCommand> { command });
+    }
+
+    protected override IRequest<Result<bool>> DeleteRangeCommand(List<long> ids)
+    {
+        return new DeleteListDropOrderItemCommand(ids);
+    }
+
+    protected override IRequest<Result<List<DropOrderItem>>> GetAllQuery()
+    {
+        return new GetAllDropOrderItemQuery();
+    }
+
+    protected override IRequest<Result<DropOrderItem>> GetByIdQuery(long id)
+    {
+        return new GetByIdDropOrderItemQuery(id);
+    }
+
+    protected override IRequest<Result<List<DropOrderItem>>> GetListByListIdQuery(List<long> ids)
+    {
+        return new GetListByListIdDropOrderItemQuery(ids);
+    }
+}

--- a/DROP-Ecommerce/src/Drop/DropCommerce.Api/Controllers/DropProduct/DropProductController.cs
+++ b/DROP-Ecommerce/src/Drop/DropCommerce.Api/Controllers/DropProduct/DropProductController.cs
@@ -1,0 +1,46 @@
+using DropCommerce.Api.Controllers.Base;
+using DropCommerce.Application.Features.Commands;
+using DropCommerce.Application.Result;
+using DropCommerce.Domain.Entity;
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+
+namespace DropCommerce.Api.Controllers;
+
+[Route("api/drop-product")]
+public class DropProductController : BaseController<DropProduct, CreateDropProductCommand, CreateListDropProductCommand, UpdateDropProductCommand, UpdateListDropProductCommand>
+{
+    public DropProductController(IMediator mediator) : base(mediator)
+    {
+    }
+
+    protected override CreateListDropProductCommand WrapCreateInRange(CreateDropProductCommand command)
+    {
+        return new CreateListDropProductCommand(new List<CreateDropProductCommand> { command });
+    }
+
+    protected override UpdateListDropProductCommand WrapUpdateInRange(UpdateDropProductCommand command)
+    {
+        return new UpdateListDropProductCommand(new List<UpdateDropProductCommand> { command });
+    }
+
+    protected override IRequest<Result<bool>> DeleteRangeCommand(List<long> ids)
+    {
+        return new DeleteListDropProductCommand(ids);
+    }
+
+    protected override IRequest<Result<List<DropProduct>>> GetAllQuery()
+    {
+        return new GetAllDropProductQuery();
+    }
+
+    protected override IRequest<Result<DropProduct>> GetByIdQuery(long id)
+    {
+        return new GetByIdDropProductQuery(id);
+    }
+
+    protected override IRequest<Result<List<DropProduct>>> GetListByListIdQuery(List<long> ids)
+    {
+        return new GetListByListIdDropProductQuery(ids);
+    }
+}

--- a/DROP-Ecommerce/src/Drop/DropCommerce.Api/Controllers/DropRegistration/DropRegistrationController.cs
+++ b/DROP-Ecommerce/src/Drop/DropCommerce.Api/Controllers/DropRegistration/DropRegistrationController.cs
@@ -1,0 +1,46 @@
+using DropCommerce.Api.Controllers.Base;
+using DropCommerce.Application.Features.Commands;
+using DropCommerce.Application.Result;
+using DropCommerce.Domain.Entity;
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+
+namespace DropCommerce.Api.Controllers;
+
+[Route("api/drop-registration")]
+public class DropRegistrationController : BaseController<DropRegistration, CreateDropRegistrationCommand, CreateListDropRegistrationCommand, UpdateDropRegistrationCommand, UpdateListDropRegistrationCommand>
+{
+    public DropRegistrationController(IMediator mediator) : base(mediator)
+    {
+    }
+
+    protected override CreateListDropRegistrationCommand WrapCreateInRange(CreateDropRegistrationCommand command)
+    {
+        return new CreateListDropRegistrationCommand(new List<CreateDropRegistrationCommand> { command });
+    }
+
+    protected override UpdateListDropRegistrationCommand WrapUpdateInRange(UpdateDropRegistrationCommand command)
+    {
+        return new UpdateListDropRegistrationCommand(new List<UpdateDropRegistrationCommand> { command });
+    }
+
+    protected override IRequest<Result<bool>> DeleteRangeCommand(List<long> ids)
+    {
+        return new DeleteListDropRegistrationCommand(ids);
+    }
+
+    protected override IRequest<Result<List<DropRegistration>>> GetAllQuery()
+    {
+        return new GetAllDropRegistrationQuery();
+    }
+
+    protected override IRequest<Result<DropRegistration>> GetByIdQuery(long id)
+    {
+        return new GetByIdDropRegistrationQuery(id);
+    }
+
+    protected override IRequest<Result<List<DropRegistration>>> GetListByListIdQuery(List<long> ids)
+    {
+        return new GetListByListIdDropRegistrationQuery(ids);
+    }
+}

--- a/DROP-Ecommerce/src/Drop/DropCommerce.Api/Controllers/DropReservation/DropReservationController.cs
+++ b/DROP-Ecommerce/src/Drop/DropCommerce.Api/Controllers/DropReservation/DropReservationController.cs
@@ -1,0 +1,46 @@
+using DropCommerce.Api.Controllers.Base;
+using DropCommerce.Application.Features.Commands;
+using DropCommerce.Application.Result;
+using DropCommerce.Domain.Entity;
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+
+namespace DropCommerce.Api.Controllers;
+
+[Route("api/drop-reservation")]
+public class DropReservationController : BaseController<DropReservation, CreateDropReservationCommand, CreateListDropReservationCommand, UpdateDropReservationCommand, UpdateListDropReservationCommand>
+{
+    public DropReservationController(IMediator mediator) : base(mediator)
+    {
+    }
+
+    protected override CreateListDropReservationCommand WrapCreateInRange(CreateDropReservationCommand command)
+    {
+        return new CreateListDropReservationCommand(new List<CreateDropReservationCommand> { command });
+    }
+
+    protected override UpdateListDropReservationCommand WrapUpdateInRange(UpdateDropReservationCommand command)
+    {
+        return new UpdateListDropReservationCommand(new List<UpdateDropReservationCommand> { command });
+    }
+
+    protected override IRequest<Result<bool>> DeleteRangeCommand(List<long> ids)
+    {
+        return new DeleteListDropReservationCommand(ids);
+    }
+
+    protected override IRequest<Result<List<DropReservation>>> GetAllQuery()
+    {
+        return new GetAllDropReservationQuery();
+    }
+
+    protected override IRequest<Result<DropReservation>> GetByIdQuery(long id)
+    {
+        return new GetByIdDropReservationQuery(id);
+    }
+
+    protected override IRequest<Result<List<DropReservation>>> GetListByListIdQuery(List<long> ids)
+    {
+        return new GetListByListIdDropReservationQuery(ids);
+    }
+}

--- a/DROP-Ecommerce/src/Drop/DropCommerce.Api/Controllers/DropTransaction/DropTransactionController.cs
+++ b/DROP-Ecommerce/src/Drop/DropCommerce.Api/Controllers/DropTransaction/DropTransactionController.cs
@@ -1,0 +1,46 @@
+using DropCommerce.Api.Controllers.Base;
+using DropCommerce.Application.Features.Commands;
+using DropCommerce.Application.Result;
+using DropCommerce.Domain.Entity;
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+
+namespace DropCommerce.Api.Controllers;
+
+[Route("api/drop-transaction")]
+public class DropTransactionController : BaseController<DropTransaction, CreateDropTransactionCommand, CreateListDropTransactionCommand, UpdateDropTransactionCommand, UpdateListDropTransactionCommand>
+{
+    public DropTransactionController(IMediator mediator) : base(mediator)
+    {
+    }
+
+    protected override CreateListDropTransactionCommand WrapCreateInRange(CreateDropTransactionCommand command)
+    {
+        return new CreateListDropTransactionCommand(new List<CreateDropTransactionCommand> { command });
+    }
+
+    protected override UpdateListDropTransactionCommand WrapUpdateInRange(UpdateDropTransactionCommand command)
+    {
+        return new UpdateListDropTransactionCommand(new List<UpdateDropTransactionCommand> { command });
+    }
+
+    protected override IRequest<Result<bool>> DeleteRangeCommand(List<long> ids)
+    {
+        return new DeleteListDropTransactionCommand(ids);
+    }
+
+    protected override IRequest<Result<List<DropTransaction>>> GetAllQuery()
+    {
+        return new GetAllDropTransactionQuery();
+    }
+
+    protected override IRequest<Result<DropTransaction>> GetByIdQuery(long id)
+    {
+        return new GetByIdDropTransactionQuery(id);
+    }
+
+    protected override IRequest<Result<List<DropTransaction>>> GetListByListIdQuery(List<long> ids)
+    {
+        return new GetListByListIdDropTransactionQuery(ids);
+    }
+}

--- a/DROP-Ecommerce/src/Drop/DropCommerce.Api/Controllers/FraudSignal/FraudSignalController.cs
+++ b/DROP-Ecommerce/src/Drop/DropCommerce.Api/Controllers/FraudSignal/FraudSignalController.cs
@@ -1,0 +1,46 @@
+using DropCommerce.Api.Controllers.Base;
+using DropCommerce.Application.Features.Commands;
+using DropCommerce.Application.Result;
+using DropCommerce.Domain.Entity;
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+
+namespace DropCommerce.Api.Controllers;
+
+[Route("api/fraud-signal")]
+public class FraudSignalController : BaseController<FraudSignal, CreateFraudSignalCommand, CreateListFraudSignalCommand, UpdateFraudSignalCommand, UpdateListFraudSignalCommand>
+{
+    public FraudSignalController(IMediator mediator) : base(mediator)
+    {
+    }
+
+    protected override CreateListFraudSignalCommand WrapCreateInRange(CreateFraudSignalCommand command)
+    {
+        return new CreateListFraudSignalCommand(new List<CreateFraudSignalCommand> { command });
+    }
+
+    protected override UpdateListFraudSignalCommand WrapUpdateInRange(UpdateFraudSignalCommand command)
+    {
+        return new UpdateListFraudSignalCommand(new List<UpdateFraudSignalCommand> { command });
+    }
+
+    protected override IRequest<Result<bool>> DeleteRangeCommand(List<long> ids)
+    {
+        return new DeleteListFraudSignalCommand(ids);
+    }
+
+    protected override IRequest<Result<List<FraudSignal>>> GetAllQuery()
+    {
+        return new GetAllFraudSignalQuery();
+    }
+
+    protected override IRequest<Result<FraudSignal>> GetByIdQuery(long id)
+    {
+        return new GetByIdFraudSignalQuery(id);
+    }
+
+    protected override IRequest<Result<List<FraudSignal>>> GetListByListIdQuery(List<long> ids)
+    {
+        return new GetListByListIdFraudSignalQuery(ids);
+    }
+}

--- a/DROP-Ecommerce/src/Drop/DropCommerce.Api/Controllers/QueueEntry/QueueEntryController.cs
+++ b/DROP-Ecommerce/src/Drop/DropCommerce.Api/Controllers/QueueEntry/QueueEntryController.cs
@@ -1,0 +1,46 @@
+using DropCommerce.Api.Controllers.Base;
+using DropCommerce.Application.Features.Commands;
+using DropCommerce.Application.Result;
+using DropCommerce.Domain.Entity;
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+
+namespace DropCommerce.Api.Controllers;
+
+[Route("api/queue-entry")]
+public class QueueEntryController : BaseController<QueueEntry, CreateQueueEntryCommand, CreateListQueueEntryCommand, UpdateQueueEntryCommand, UpdateListQueueEntryCommand>
+{
+    public QueueEntryController(IMediator mediator) : base(mediator)
+    {
+    }
+
+    protected override CreateListQueueEntryCommand WrapCreateInRange(CreateQueueEntryCommand command)
+    {
+        return new CreateListQueueEntryCommand(new List<CreateQueueEntryCommand> { command });
+    }
+
+    protected override UpdateListQueueEntryCommand WrapUpdateInRange(UpdateQueueEntryCommand command)
+    {
+        return new UpdateListQueueEntryCommand(new List<UpdateQueueEntryCommand> { command });
+    }
+
+    protected override IRequest<Result<bool>> DeleteRangeCommand(List<long> ids)
+    {
+        return new DeleteListQueueEntryCommand(ids);
+    }
+
+    protected override IRequest<Result<List<QueueEntry>>> GetAllQuery()
+    {
+        return new GetAllQueueEntryQuery();
+    }
+
+    protected override IRequest<Result<QueueEntry>> GetByIdQuery(long id)
+    {
+        return new GetByIdQueueEntryQuery(id);
+    }
+
+    protected override IRequest<Result<List<QueueEntry>>> GetListByListIdQuery(List<long> ids)
+    {
+        return new GetListByListIdQueueEntryQuery(ids);
+    }
+}

--- a/DROP-Ecommerce/src/Drop/DropCommerce.Api/Controllers/QueueSession/QueueSessionController.cs
+++ b/DROP-Ecommerce/src/Drop/DropCommerce.Api/Controllers/QueueSession/QueueSessionController.cs
@@ -1,0 +1,46 @@
+using DropCommerce.Api.Controllers.Base;
+using DropCommerce.Application.Features.Commands;
+using DropCommerce.Application.Result;
+using DropCommerce.Domain.Entity;
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+
+namespace DropCommerce.Api.Controllers;
+
+[Route("api/queue-session")]
+public class QueueSessionController : BaseController<QueueSession, CreateQueueSessionCommand, CreateListQueueSessionCommand, UpdateQueueSessionCommand, UpdateListQueueSessionCommand>
+{
+    public QueueSessionController(IMediator mediator) : base(mediator)
+    {
+    }
+
+    protected override CreateListQueueSessionCommand WrapCreateInRange(CreateQueueSessionCommand command)
+    {
+        return new CreateListQueueSessionCommand(new List<CreateQueueSessionCommand> { command });
+    }
+
+    protected override UpdateListQueueSessionCommand WrapUpdateInRange(UpdateQueueSessionCommand command)
+    {
+        return new UpdateListQueueSessionCommand(new List<UpdateQueueSessionCommand> { command });
+    }
+
+    protected override IRequest<Result<bool>> DeleteRangeCommand(List<long> ids)
+    {
+        return new DeleteListQueueSessionCommand(ids);
+    }
+
+    protected override IRequest<Result<List<QueueSession>>> GetAllQuery()
+    {
+        return new GetAllQueueSessionQuery();
+    }
+
+    protected override IRequest<Result<QueueSession>> GetByIdQuery(long id)
+    {
+        return new GetByIdQueueSessionQuery(id);
+    }
+
+    protected override IRequest<Result<List<QueueSession>>> GetListByListIdQuery(List<long> ids)
+    {
+        return new GetListByListIdQueueSessionQuery(ids);
+    }
+}

--- a/DROP-Ecommerce/src/Drop/DropCommerce.Api/Controllers/WaitlistEntry/WaitlistEntryController.cs
+++ b/DROP-Ecommerce/src/Drop/DropCommerce.Api/Controllers/WaitlistEntry/WaitlistEntryController.cs
@@ -1,0 +1,46 @@
+using DropCommerce.Api.Controllers.Base;
+using DropCommerce.Application.Features.Commands;
+using DropCommerce.Application.Result;
+using DropCommerce.Domain.Entity;
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+
+namespace DropCommerce.Api.Controllers;
+
+[Route("api/waitlist-entry")]
+public class WaitlistEntryController : BaseController<WaitlistEntry, CreateWaitlistEntryCommand, CreateListWaitlistEntryCommand, UpdateWaitlistEntryCommand, UpdateListWaitlistEntryCommand>
+{
+    public WaitlistEntryController(IMediator mediator) : base(mediator)
+    {
+    }
+
+    protected override CreateListWaitlistEntryCommand WrapCreateInRange(CreateWaitlistEntryCommand command)
+    {
+        return new CreateListWaitlistEntryCommand(new List<CreateWaitlistEntryCommand> { command });
+    }
+
+    protected override UpdateListWaitlistEntryCommand WrapUpdateInRange(UpdateWaitlistEntryCommand command)
+    {
+        return new UpdateListWaitlistEntryCommand(new List<UpdateWaitlistEntryCommand> { command });
+    }
+
+    protected override IRequest<Result<bool>> DeleteRangeCommand(List<long> ids)
+    {
+        return new DeleteListWaitlistEntryCommand(ids);
+    }
+
+    protected override IRequest<Result<List<WaitlistEntry>>> GetAllQuery()
+    {
+        return new GetAllWaitlistEntryQuery();
+    }
+
+    protected override IRequest<Result<WaitlistEntry>> GetByIdQuery(long id)
+    {
+        return new GetByIdWaitlistEntryQuery(id);
+    }
+
+    protected override IRequest<Result<List<WaitlistEntry>>> GetListByListIdQuery(List<long> ids)
+    {
+        return new GetListByListIdWaitlistEntryQuery(ids);
+    }
+}

--- a/DROP-Ecommerce/src/Drop/DropCommerce.Api/Program.cs
+++ b/DROP-Ecommerce/src/Drop/DropCommerce.Api/Program.cs
@@ -13,4 +13,6 @@ if (app.Environment.IsDevelopment())
 
 app.UseHttpsRedirection();
 
+app.MapControllers();
+
 app.Run();


### PR DESCRIPTION
# Conclusão

  - BaseController genérico com 9 endpoints CRUD via MediatR
  - 14 controllers concretos para todas as entidades do módulo Drop
  - AddRangeAsync adicionado ao repositório genérico
  - Controllers organizados em pastas por entidade
  - Delegação unitário → range (Add → AddRange, Update → UpdateRange, Delete → DeleteRange)
  
  Endpoints disponíveis

  - POST /api/{entity}/Add e /AddRange
  - PUT /api/{entity}/Update e /UpdateRange
  - DELETE /api/{entity}/Delete/{id} e /DeleteRange
  - GET /api/{entity}/GetAll e /GetById/{id}
  - POST /api/{entity}/GetListByListId

# Issue
Closes #47 